### PR TITLE
Increase replicas for frontend to 2

### DIFF
--- a/ggapp/charts/app/Chart.yaml
+++ b/ggapp/charts/app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: app
 description: A Helm chart for the web app for the ggapp helm chart
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.0.0"

--- a/ggapp/charts/app/templates/app-deployment.yaml
+++ b/ggapp/charts/app/templates/app-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     name: app
   name: app
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       name: app

--- a/ggapp/charts/app/templates/app-service.yaml
+++ b/ggapp/charts/app/templates/app-service.yaml
@@ -11,6 +11,7 @@ spec:
     - name: "8080"
       port: 8080
       targetPort: 8080
+      nodePort: 32080
   selector:
     name: app
 status:


### PR DESCRIPTION
- Add NodePort to be used to permit external access.
- Required in order to improve HA, and potentially test forwarding.
- Bump chart version